### PR TITLE
NO-REF: Bump mermaid to 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gitbook-plugin-mermaid-gb3",
   "description": "Plugin for GitBook 3 which renders Mermaid flow from markdown. Tries to work cross platform (windows/unix)",
   "main": "index.js",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "engines": {
     "gitbook": "*"
   },
@@ -13,7 +13,7 @@
     "copy:book": "mkdir -p dist/book && cp -R book/ dist/book"
   },
   "dependencies": {
-    "mermaid": "^0.5.8"
+    "mermaid": "^6.0.0"
   },
   "devDependencies": {
     "rimraf": "^2.5.2"


### PR DESCRIPTION
This bumps mermaid to higher major version to be compatible with the docs and be less buggy in general.